### PR TITLE
Update tests to be compatible with rspec 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'em-synchrony'
 group :test do
   gem 'rake', '~> 10.0'
   gem 'rspec'
+  gem 'rspec-its'
   gem 'timecop'
   gem 'codeclimate-test-reporter'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ Bundler.setup
 end
 
 require 'rubykiq'
+require 'rspec/its'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |c|

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -20,7 +20,7 @@ describe Rubykiq::Client do
         subject { client }
         its(:namespace) { should eq driver }
         its(:driver) { should be driver }
-        its(:retry) { should be_true }
+        its(:retry) { should eq true }
         its(:queue) { should eq 'default' }
       end
 


### PR DESCRIPTION
* include rspec-its gem for `its(:foo)` tests
* * use `should eq true` instead of `should be_true`