### PR TITLE
fix(Redis): Accept a hash to open connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ require 'rubykiq'
 # will also detect REDIS_URL, REDIS_PROVIDER and REDISTOGO_URL ENV variables
 Rubykiq.url = 'redis://127.0.0.1:6379'
 
+# sentinels support
+Rubykiq.sentinels = [{:host => "127.0.0.1", :port => 26380}, {:host => "127.0.0.1", :port => 26381}]
+Rubykiq.role = :master # default
+
 # alternative driver support ( :ruby, :hiredis, :synchrony )
 Rubykiq.driver = :synchrony
 

--- a/lib/rubykiq/client.rb
+++ b/lib/rubykiq/client.rb
@@ -12,6 +12,9 @@ module Rubykiq
       :redis_pool_timeout,
       :url,
       :namespace,
+      :sentinels,
+      :role,
+      :master_name,
       :driver,
       :retry,
       :queue
@@ -23,6 +26,9 @@ module Rubykiq
       redis_pool_timeout: 1,
       url: nil,
       namespace: nil,
+      sentinels: [],
+      role: :master,
+      master_name: nil,
       driver: :ruby,
       retry: true,
       queue: 'default'
@@ -49,6 +55,7 @@ module Rubykiq
     # @return [::ConnectionPool]
     def connection_pool(options = {}, &block)
       options = valid_options.merge(options)
+      options.delete(:sentinels) if options[:sentinels].empty?
       initialize_connection_pool(options) unless defined?(@connection_pool)
 
       if block_given?

--- a/lib/rubykiq/connection.rb
+++ b/lib/rubykiq/connection.rb
@@ -11,10 +11,9 @@ module Rubykiq
     #
     # @param options [Hash]
     def initialize(options = {})
-      url = options.delete(:url) { determine_redis_provider }
+      options[:url] ||= determine_redis_provider
       namespace = options.delete(:namespace)
-      driver = options.delete(:driver)
-      @redis_connection = initialize_conection(url, namespace, driver)
+      @redis_connection = initialize_conection(options, namespace)
       @redis_client = @redis_connection.client
       @redis_connection
     end
@@ -26,8 +25,8 @@ module Rubykiq
       ENV['REDISTOGO_URL'] || ENV['REDIS_PROVIDER'] || ENV['REDIS_URL'] || 'redis://localhost:6379/0'
     end
 
-    def initialize_conection(url, namespace, driver)
-      client = ::Redis.new(url: url, driver: driver)
+    def initialize_conection(options, namespace)
+      client = ::Redis.new(options)
       ::Redis::Namespace.new(namespace, redis: client)
     end
   end


### PR DESCRIPTION
I need this changes to support [Redis Sentinel](https://github.com/redis/redis-rb#sentinel-support).
Also this change will make it easier to accept any other Redis initialization parameters.
